### PR TITLE
fix: Disable OpenMP optimizations on Windows

### DIFF
--- a/VIPRA/models/calm_pedestrian_model.cpp
+++ b/VIPRA/models/calm_pedestrian_model.cpp
@@ -423,10 +423,12 @@ void CalmPedestrianModel::calculateDistanceMatrices()
     // Parallelize this loop using the guided scheduling, since the initial
     // workloads will complete faster than subsequent ones, and we want openmp
     // to front-load the work across cores.
+    #ifndef _WIN32
     #pragma omp parallel for \
         shared(pedestrianCoordinates, obstacleCoordinates) \
         default(none) \
         schedule(guided)
+    #endif
     for (int i = 0; i < this->numPedestrians; ++i)
     {
         // Only compute up to i since we only need to compute the distances
@@ -514,17 +516,21 @@ std::pair<std::string, int>
 
     std::pair<std::string, int> newNearestNeighbor;
 
+    #ifndef _WIN32
     #pragma omp parallel shared(nearest, \
             originSet, \
             nearestDistance, \
             pedestrianIndex) \
             default(none)
+    #endif
     {
         int localNearest = NOT_FOUND;
         std::string localOriginSet = "P";
         FLOATING_NUMBER localNearestDistance = FLT_MAX;
 
+        #ifndef _WIN32
         #pragma omp for nowait
+        #endif
         for (int j = 0; j < numObstacles; ++j)
         {
             if (pedestrianIndex != j && j < numPedestrians &&
@@ -553,7 +559,9 @@ std::pair<std::string, int>
             }
         }
 
+        #ifndef _WIN32
         #pragma omp critical
+        #endif
         {
             if (localNearestDistance < nearestDistance)
             {


### PR DESCRIPTION
For an unknown reason, Windows does not run OpenMP workloads very well.
Disable it on that system to avoid performance
penalties for the time being.
Also delete an unused file.

I asked about this in StackOverflow here: https://stackoverflow.com/questions/68377498/parallelization-with-openmp-is-much-slower-on-windows-than-on-linux-why